### PR TITLE
Specify the main branch for website deploys

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -26,6 +26,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v5
+              with:
+                  ref: main
 
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v5


### PR DESCRIPTION
Fixes the deployment workflow of the website to use the `main` branch instead of the reference for the pull request (which is the incoming branch).

Resolves #10 