### PR TITLE
Specify the main branch for infra deploys

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -28,6 +28,8 @@ jobs:
         steps:
             - name: Checkout repo
               uses: actions/checkout@v5
+              with:
+                  ref: main
 
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v5


### PR DESCRIPTION
Adds the same fix as for #10 to the infra-deploy workflow